### PR TITLE
WIP: train/validation/test split

### DIFF
--- a/gbif_dl/io.py
+++ b/gbif_dl/io.py
@@ -14,6 +14,7 @@ else:
 
 from collections.abc import Iterable
 
+
 import filetype
 import aiofiles
 import aiohttp
@@ -25,8 +26,9 @@ from .utils import watchdog, run_async
 class MediaData(TypedDict):
     """ Media dict representation received from api or dwca generators"""
     url: str
-    basename: str
-    label: str
+    basename: Optional[str]
+    label: Optional[str]
+    split: Optional[str]
 
 async def download_single(
     item: MediaData,
@@ -57,21 +59,25 @@ async def download_single(
         url = item.get('url')
         label = item.get('label')
         basename = item.get('basename')
+        split = item.get('split')
     else:
         url = item
-        label, basename = None, None
+        label, basename, split = None, None, None
+
+    label_path = Path(root)
+
+    if split is not None:
+        label_path /= Path(split)
 
     # create subfolder when label is a single str
     if isinstance(label, str):
-        label_path = Path(root, label)
-    # otherwise make it a flat file hierarchy
-    else:
-        label_path = Path(root)
+        # append label path
+        label_path /= Path(label)
 
     label_path.mkdir(parents=True, exist_ok=True)
 
     if basename is None:
-        # hash the url, which later becomes the datatype
+        # hash the url
         basename = hashlib.sha1(
             url.encode('utf-8')
         ).hexdigest()


### PR DESCRIPTION
add support for train/validation/test splits, closing #18 

* [X] add split support for api
* [X] add split support for io

this PR comes with some API changes:

### subsets for io

 the basic download dictionary format now supports `subsets`:

```python
urls = [
    {
        'url': 'https://bs.plantnet.org/image/o/6d5ed1f1769b4818ed5a234670dba742bf5b28a5',
        'basename': 'e75239cd029162c81f16a6d6afb1057d2437bcc8',
        'label': '3189866',
        'subset': 'train'
    },
    {
        'url': 'https://bs.plantnet.org/image/o/6d5ed1f1769b4818ed5a234670dba742bf5b28a5',
        'basename': '6d5ed1f1769b4818ed5a234670dba742bf5b28a5',
        'label': '3189866',
        'subset': 'test'
    }
]
```
this would save 

```
root/train/3189866/e75239cd029162c81f16a6d6afb1057d2437bcc8.jpg
root/test/3189866/6d5ed1f1769b4818ed5a234670dba742bf5b28a5.jpg
```

### random subsets

random subsets can be given as a dict of class names and it's propability.
e.g. `{'train': 0.9, test': 0.1}` will result in 90% of the items 
go into a `train` subfolder and 10% go into 10%. The propabilities have to sum up to `1.0` to avoid an error.

```python
gbif_dl.io.download(
    async_gen_from_list(urls),
    root="random_split_test",
    random_splits={'train': 0.9, 'test': 0.1}
)
```

will put 90% of the examples into train and 10% into test

### gbif api subsets 

The GBIF api can also split into subsets using api streams. E.g. in the following example, the subsets `train` and `test` can directly link to some of the query parameters. The values can be single values, lists or even a wildcard (`"*"`) which matches to all values.

```
queries = {
    "speciesKey": [
        5352251, # "Robinia pseudoacacia L"
        3190653, # "Ailanthus altissima (Mill.) Swingle"
        3189866  # "Acer negundo L"
    ],
    "datasetKey": [
        "7a3679ef-5582-4aaa-81f0-8c2545cafc81",
        "50c9509d-22c7-4a22-a47d-8c48425ef4a7"
    ]
}
data_generator = gbif_dl.api.generate_urls(
    queries=queries,
    split_streams_by=["datasetKey", "speciesKey"],
    subset_streams={
        "train": { "speciesKey": 5352251},
        "test": { "speciesKey": "*" }
    },
)
```