### PR TITLE
fix DWCAReader for occurrence samples without image extensions

### DIFF
--- a/gbif_dl/generators/dwca.py
+++ b/gbif_dl/generators/dwca.py
@@ -55,6 +55,11 @@ def dwca_generator(
                     if ext.data[mmqualname + "type"] == mediatype:
                         img_extensions.append(ext.data)
 
+            # skip rows with no image data, 
+            # random.choice() will fail with an empty list
+            if not img_extensions:
+                continue
+
             if one_media_per_occurrence:
                 media = [random.choice(img_extensions)]
             else:


### PR DESCRIPTION
If a row in DWCA occurrence data has no image extensions, and only one occurrence should be picked (the default), the respective code path will throw an exception, caused by random.choice() operating on an empty list.

To fix, simply skip occurrence samples with no image extensions.